### PR TITLE
[FIX]修复教程不适用于部署的问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,15 @@ Open `app/Providers/AppServiceProvider.php`, and call the `Config::load()` metho
 namespace App\Providers;
 
 use Encore\Admin\Config\Config;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
 {
     public function boot()
     {
-        if (class_exists(Config::class)) {
+        $table = config('admin.extensions.config.table', 'admin_config');
+        if (Schema::hasTable($table)) {
             Config::load();
         }
     }


### PR DESCRIPTION
部署时config表并不存在，而Config::load()会执行表操作，导致错误。
判断class_exists依然不能解决表不存在的情况