### PR TITLE
empty string allowed for value column

### DIFF
--- a/src/ConfigController.php
+++ b/src/ConfigController.php
@@ -101,7 +101,11 @@ class ConfigController
 
         $form->display('id', 'ID');
         $form->text('name')->rules('required');
-        $form->textarea('value')->rules('required');
+        if (config('admin.extensions.config.valueEmptyStringAllowed', false)) {
+            $form->textarea('value');
+        } else {
+            $form->textarea('value')->rules('required');
+        }
         $form->textarea('description');
 
         $form->display('created_at');

--- a/src/ConfigModel.php
+++ b/src/ConfigModel.php
@@ -19,4 +19,19 @@ class ConfigModel extends Model
 
         $this->setTable(config('admin.extensions.config.table', 'admin_config'));
     }
+
+    /**
+     * Set the config's value.
+     *
+     * @param null $value
+     * @return string|null
+     */
+    public function setValueAttribute($value = null)
+    {
+        if (config('admin.extensions.config.valueEmptyStringAllowed', false)) {
+            $this->attributes['value'] = is_null($value) ? '' : $value;
+        } else {
+            $this->attributes['value'] = $value;
+        }
+    }
 }

--- a/src/ConfigModel.php
+++ b/src/ConfigModel.php
@@ -24,6 +24,7 @@ class ConfigModel extends Model
      * Set the config's value.
      *
      * @param null $value
+     *
      * @return string|null
      */
     public function setValueAttribute($value = null)

--- a/src/ConfigModel.php
+++ b/src/ConfigModel.php
@@ -23,9 +23,7 @@ class ConfigModel extends Model
     /**
      * Set the config's value.
      *
-     * @param null $value
-     *
-     * @return string|null
+     * @param string|null $value
      */
     public function setValueAttribute($value = null)
     {


### PR DESCRIPTION
An empty string cannot be set in the Value column.
So it is useful to include a setting that allows null characters!


```php
// config/admin.php


    'extensions' => [
        'config' => [
            'valueEmptyStringAllowed' => true,
        ],
    ],

```


<img width="647" alt="Screen Shot 2019-10-11 at 0 22 06" src="https://user-images.githubusercontent.com/19170560/66582714-2eead900-ebbd-11e9-9ec2-dd93c4736468.png">

Thanks!